### PR TITLE
Added support for alternative ssh ports

### DIFF
--- a/lib/command.php
+++ b/lib/command.php
@@ -141,7 +141,7 @@ class WP_Deploy_Flow_Command extends WP_CLI_Command {
 		$out['db_user'] = escapeshellarg( $out['db_user'] );
 		$out['db_host'] = escapeshellarg( $out['db_host'] );
 		$out['db_password'] = escapeshellarg( $out['db_password'] );
-		$out['ssh_port'] = ( isset($out['ssh_port']) ) ? escapeshellarg( $out['ssh_port']) : 22;
+		$out['ssh_port'] = ( isset($out['ssh_port']) ) ? intval( $out['ssh_port']) : 22;
 
 		if ( $out['ssh_db_host'] && $tunnel ) {
 			$com = sprintf( 'ssh -f -L 3310:127.0.01:%s %s@%s sleep 600 >> logfile', ( $out['db_port'] ? $out['db_port'] : 3306 ), $out['ssh_db_user'], escapeshellarg( $out['ssh_db_host'] ) );

--- a/lib/command.php
+++ b/lib/command.php
@@ -22,8 +22,6 @@ class WP_Deploy_Flow_Command extends WP_CLI_Command {
 			WP_CLI::error( "$env environment is locked, you cannot push to it" );
 			return;
 		}
-		
-		$ssh_port = ($ssh_port) ? $ssh_port : 22;
 
 		$siteurl = get_option( 'siteurl' );
 
@@ -66,7 +64,6 @@ class WP_Deploy_Flow_Command extends WP_CLI_Command {
 
 	public function push_files( $args = array() ) {
 		extract( self::_prepare_and_extract( $args, false ) );
-                $ssh_port = ($ssh_port) ? $ssh_port : 22;
 		if ( $locked === true ) {
 			WP_CLI::error( "$env environment is locked, you cannot push to it" );
 			return;
@@ -91,7 +88,6 @@ class WP_Deploy_Flow_Command extends WP_CLI_Command {
 		if ( constant( $const ) === true ) {
 			return WP_CLI::error( ENVIRONMENT . ' env is locked, you can not pull to your local copy' );
 		}
-		$ssh_port = ($ssh_port) ? $ssh_port : 22;
 		$host = $db_host . ':' . $db_port;
 
 		$wpdb = new wpdb( $db_user, $db_password, $db_name, $host );
@@ -113,7 +109,7 @@ class WP_Deploy_Flow_Command extends WP_CLI_Command {
 		if ( constant( $const ) === true ) {
 			return WP_CLI::error( ENVIRONMENT . ' env is locked, you can not pull to your local copy' );
 		}
-		$ssh_port = ($ssh_port) ? $ssh_port : 22;
+		
 		$host = $db_host.':'.$db_port;
 
 		if ( $ssh_host ) {
@@ -145,6 +141,7 @@ class WP_Deploy_Flow_Command extends WP_CLI_Command {
 		$out['db_user'] = escapeshellarg( $out['db_user'] );
 		$out['db_host'] = escapeshellarg( $out['db_host'] );
 		$out['db_password'] = escapeshellarg( $out['db_password'] );
+		$out['ssh_port'] = ( isset($out['ssh_port']) ) ? escapeshellarg( $out['ssh_port']) : 22;
 
 		if ( $out['ssh_db_host'] && $tunnel ) {
 			$com = sprintf( 'ssh -f -L 3310:127.0.01:%s %s@%s sleep 600 >> logfile', ( $out['db_port'] ? $out['db_port'] : 3306 ), $out['ssh_db_user'], escapeshellarg( $out['ssh_db_host'] ) );


### PR DESCRIPTION
I had a need to use a port number other than 22 for my deployment, I have edited this to support the use of STAGING_SSH_PORT, PROD_SSH_PORT etc in WP-config.php
