### PR TITLE
Make rsync in pusher do 755 permissions for Dirs, and 644 for Files

### DIFF
--- a/lib/pusher.php
+++ b/lib/pusher.php
@@ -59,7 +59,7 @@ class WP_Deploy_Flow_Pusher {
     $excludes = array_reduce( $excludes, function($acc, $value) { $acc.= "--exclude \"$value\" "; return $acc; } );
 
 		if ( $ssh_host ) {
-      $command = "rsync -avz -e 'ssh -p $ssh_port' $local_path $ssh_user@$ssh_host:$remote_path $excludes";
+      $command = "rsync -avz -e 'ssh -p $ssh_port' --chmod=Du=rwx,Dg=rx,Do=rx,Fu=rw,Fg=r,Fo=r $local_path $ssh_user@$ssh_host:$remote_path $excludes";
     } else {
       $command = "rsync -avz $local_path $remote_path $excludes";
     }


### PR DESCRIPTION
I am running a vagrant box and when I deployed to the production server I was getting 500 errors. This was because the vagrant box has group write permissions set for the files and wp-deploy-flow's rsync command was preserving the permissions and copying to the production server where the server refused the serve the files out as it saw a group write permission as a security risk.

So I changed the rsync command in the pusher so that it sets 755 for directories and 644 for files and that fixed the problem.
